### PR TITLE
Fix needs-flowmax

### DIFF
--- a/src/tests/needs-flowmax.coffee
+++ b/src/tests/needs-flowmax.coffee
@@ -26,79 +26,87 @@ tests =
   ,
     code: '''
       flowMax(
-        renderNothing
+        renderNothing()
       )
     '''
   ,
     code: '''
-      flowMax(
-        returns(1)
+      const addSomething = renderNothing()
+    '''
+  ,
+    code: '''
+      const addSomething = branch(
+        (({x}) => x, renderNothing())
       )
+    '''
+  ,
+    code: '''
+      const addSomething = addWrapper(
+        ({render}) => <>{render()}</>
+      )
+    '''
+  ,
+    code: '''
+      const addSomething = addWrapperHOC(
+        ({render}) => <>{render()}</>
+      )
+    '''
+  ,
+    code: '''
+      const addSomething = () => {
+        addPropTypes({x: PropTypes.string})
+      }
     '''
   ,
     code: '''
       flow(
-        branch(({x}) => x > 1, addProps({x: 3})),
+        branchPure(({x}) => x, a)
       )
-    '''
-  ,
-    code: '''
-      flowMax(
-        branch(({x}) => x > 1, renderNothing),
-      )
-    '''
-  ,
-    code: '''
-      flowMax(
-        branch(({x}) => x > 1, returns(3)),
-      )
-    '''
-  ,
-    code: '''
-      flowMax(
-        addProps({x: 1}),
-        addPropTypes({x: PropTypes.number.isRequired}),
-        ({x}) => <div>{x}</div>
-      )
-    '''
-  ,
-    code: '''
-      import {renderNothing} from 'ad-hok'
     '''
   ]
   invalid: [
     code: '''
       flow(
-        renderNothing
-      )
-    '''
-    errors: [error 'renderNothing']
-  ,
-    code: '''
-      returns(1)
-    '''
-    errors: [error 'returns']
-  ,
-    code: '''
-      flow(
-        returns(1)
-      )
-    '''
-    errors: [error 'returns']
-  ,
-    code: '''
-      flow(
-        branch(({x}) => x > 1, renderNothing),
+        renderNothing()
       )
     '''
     errors: [error 'renderNothing']
   ,
     code: '''
       flow(
-        branch(({x}) => x > 1, returns(3)),
+        returns(() => 1)
       )
     '''
     errors: [error 'returns']
+  ,
+    code: '''
+      flow(
+        branch(({x}) => x > 1, renderNothing()),
+      )
+    '''
+    errors: [error 'branch']
+  ,
+    code: '''
+      flow(
+        branch(({x}) => x > 1, returns(() => 3)),
+      )
+    '''
+    errors: [error 'branch']
+  ,
+    code: '''
+      flow(
+        branch(({x}) => x > 1, returns(() => 3)),
+      )
+    '''
+    errors: [error 'branch']
+  ,
+    # branch() is always magic
+    code: '''
+      flow(
+        branch(({x}) => x > 1, addProps({x: 3})),
+      )
+    '''
+    errors: [error 'branch']
   ,
     code: '''
       flow(
@@ -112,11 +120,43 @@ tests =
     code: '''
       flowMax(
         flow(
-          branch(({x}) => x > 1, renderNothing),
+          branch(({x}) => x > 1, renderNothing()),
         )
       )
     '''
-    errors: [error 'renderNothing']
+    errors: [error 'branch']
+  ,
+    # catch returns() inside branchPure()
+    code: '''
+      flow(
+        branchPure(({x}) => x, returns(() => 1))
+      )
+    '''
+    errors: [error 'returns']
+  ,
+    # addWrapper()
+    code: '''
+      flow(
+        addWrapper(({render}) => <div>{render()}</div>)
+      )
+    '''
+    errors: [error 'addWrapper']
+  ,
+    # addWrapperHOC()
+    code: '''
+      flow(
+        addWrapperHOC(withNavigation)
+      )
+    '''
+    errors: [error 'addWrapperHOC']
+  ,
+    # nested flowMax()
+    code: '''
+      flow(
+        flowMax(something())
+      )
+    '''
+    errors: [error 'flowMax']
   ]
 
 config =

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -1,8 +1,8 @@
-isFlowMax = ({callee}) ->
-  callee.type is 'Identifier' and callee.name is 'flowMax'
+isFlowMax = (node) ->
+  node?.callee?.type is 'Identifier' and node.callee.name is 'flowMax'
 
-isFlow = ({callee}) ->
-  callee.type is 'Identifier' and callee.name is 'flow'
+isFlow = (node) ->
+  node?.callee?.type is 'Identifier' and node.callee.name is 'flow'
 
 magicHelperNames = [
   'returns'
@@ -12,6 +12,11 @@ magicHelperNames = [
   'addWrapperHOC'
   'branch'
 ]
+
+isMagic = (node) ->
+  return yes if isFlowMax node
+  return unless node?.callee?.type is 'Identifier'
+  node.callee.name in magicHelperNames
 
 nonmagicHelperNames = [
   'addState'
@@ -25,13 +30,11 @@ nonmagicHelperNames = [
   'branchPure'
 ]
 
-needsFlowMax = ({callee, name}) ->
-  if callee?
-    return no unless callee.type is 'Identifier'
-    return callee.name in ['returns', 'addPropTypes']
-  name is 'renderNothing'
-
 isFunction = (node) ->
   node?.type in ['FunctionExpression', 'ArrowFunctionExpression']
 
-module.exports = {isFlowMax, isFlow, needsFlowMax, magicHelperNames, nonmagicHelperNames, isFunction}
+isBranchPure = (node) ->
+  return unless node?.callee?.type is 'Identifier'
+  node.callee.name is 'branchPure'
+
+module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isBranchPure}


### PR DESCRIPTION
In this PR:
- `needs-flowmax` didn't understand indirection and was out-of-date

Implementation-wise, instead of `needs-flowmax` looking for magic calls and then flagging if there wasn't an enclosing `flowMax()` (which wouldn't work for indirection/"secondary helpers"), it looks at the immediate arguments to a `flow()` and flags if any of them are magic

The relationship between `needs-flowmax` and `prefer-flowmax` should be:

`needs-flowmax` flags *definite errors*. `prefer-flowmax` only flags other things eg indirection (there shouldn't be duplicate flaggings from `needs-flowmax` and `prefer-flowmax` on a definite error)