### PR TITLE
needs-flowmax fixer

### DIFF
--- a/src/tests/needs-flowmax.coffee
+++ b/src/tests/needs-flowmax.coffee
@@ -77,6 +77,12 @@ tests =
         returns(() => 1)
       )
     '''
+    # don't fix unless shouldFix is set
+    output: '''
+      flow(
+        returns(() => 1)
+      )
+    '''
     errors: [error 'returns']
   ,
     code: '''
@@ -157,6 +163,19 @@ tests =
       )
     '''
     errors: [error 'flowMax']
+  ,
+    code: '''
+      flow(
+        returns(() => 1)
+      )
+    '''
+    output: '''
+      flowMax(
+        returns(() => 1)
+      )
+    '''
+    errors: [error 'returns']
+    options: [shouldFix: yes]
   ]
 
 config =

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -37,4 +37,8 @@ isBranchPure = (node) ->
   return unless node?.callee?.type is 'Identifier'
   node.callee.name is 'branchPure'
 
-module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isBranchPure}
+getFlowToFlowMaxFixer = ({node, context}) ->
+  (fixer) ->
+    fixer.replaceText node.callee, 'flowMax'
+
+module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isBranchPure, getFlowToFlowMaxFixer}


### PR DESCRIPTION
In this PR:
- Have `needs-flowmax` update `flow()` -> `flowMax()` if the `shouldFix` option is set

This "fix" will leave the file in a broken state unless you're using [`eslint-plugin-known-imports`](https://github.com/helixbass/eslint-plugin-known-imports) (that's why it's "hidden" behind the `shouldFix` option rather than fixing by default)

But if you're using `known-imports`, it's very nice, as the `flow()` -> `flowMax()` will trigger importing `flowMax` and/or removing the `flow` import if need be