### PR TITLE
prefer-flowmax

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
 {flow, map: fmap, fromPairs: ffromPairs} = require 'lodash/fp'
 
-ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax']
+ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax']
 
 rules = do flow(
   -> ruleNames

--- a/src/rules/needs-flowmax.coffee
+++ b/src/rules/needs-flowmax.coffee
@@ -11,6 +11,7 @@ module.exports =
       properties:
         shouldFix:
           type: 'boolean'
+      additionalProperties: no
     ]
     fixable: 'code'
 

--- a/src/rules/prefer-flowmax.coffee
+++ b/src/rules/prefer-flowmax.coffee
@@ -7,7 +7,7 @@ module.exports =
       category: 'Possible Errors'
       recommended: yes
     schema: [
-      enum: ['always', 'when-using-unknown-helpers']
+      enum: ['always', 'whenUsingUnknownHelpers']
     ,
       type: 'object'
       properties:

--- a/src/rules/prefer-flowmax.coffee
+++ b/src/rules/prefer-flowmax.coffee
@@ -1,0 +1,62 @@
+{isFlow, isMagic, isBranchPure, getFlowToFlowMaxFixer, isNonmagicHelper, isFunction} = require '../util'
+
+module.exports =
+  meta:
+    docs:
+      description: 'Flag flow() calls that could be converted to flowMax()'
+      category: 'Possible Errors'
+      recommended: yes
+    schema: [
+      enum: ['always', 'when-using-unknown-helpers']
+    ,
+      type: 'object'
+      properties:
+        shouldFix:
+          type: 'boolean'
+        whitelist:
+          type: 'array'
+          items:
+            type: 'string'
+      additionalProperties: no
+    ]
+    fixable: 'code'
+
+  create: (context) ->
+    variant = context.options[0] ? 'always'
+    {whitelist = [], shouldFix} = context.options[1] ? {}
+
+    report = (node) ->
+      context.report {
+        node
+        message: "Use flowMax() instead"
+        fix:
+          if shouldFix
+            getFlowToFlowMaxFixer {node, context}
+          else
+            null
+      }
+
+    CallExpression: (node) ->
+      return unless isFlow node
+      if variant is 'always'
+        return report node
+
+      checkArgument = (argument) ->
+        # don't overlap with needs-flowmax
+        if isMagic argument
+          return shouldReturn: yes
+        if isNonmagicHelper argument
+          if isBranchPure argument
+            for branchPureArgument in argument.arguments
+              {shouldReturn} = checkArgument branchPureArgument
+              if shouldReturn
+                return shouldReturn: yes
+          return {}
+        if isFunction argument
+          return {}
+        report node
+        return shouldReturn: yes
+
+      for argument in node.arguments
+        {shouldReturn} = checkArgument argument
+        return if shouldReturn

--- a/src/rules/prefer-flowmax.coffee
+++ b/src/rules/prefer-flowmax.coffee
@@ -36,6 +36,10 @@ module.exports =
             null
       }
 
+    isWhitelisted = (argument) ->
+      return no unless argument?
+      argument.callee?.name in whitelist or argument.name in whitelist
+
     CallExpression: (node) ->
       return unless isFlow node
       if variant is 'always'
@@ -53,6 +57,8 @@ module.exports =
                 return shouldReturn: yes
           return {}
         if isFunction argument
+          return {}
+        if isWhitelisted argument
           return {}
         report node
         return shouldReturn: yes

--- a/src/tests/prefer-flowmax.coffee
+++ b/src/tests/prefer-flowmax.coffee
@@ -17,7 +17,7 @@ tests =
         addProps({a: 1})
       )
     '''
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     # don't duplicate needs-flowmax
     code: '''
@@ -25,14 +25,14 @@ tests =
         addPropTypes({a: 1})
       )
     '''
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     code: '''
       flow(
         branchPure(({x}) => x, returns(() => 2))
       )
     '''
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     # functions are ok
     code: '''
@@ -40,7 +40,7 @@ tests =
         ({x}) => x
       )
     '''
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     # whitelist call
     code: '''
@@ -48,7 +48,7 @@ tests =
         addSomethingNonmagic()
       )
     '''
-    options: ['when-using-unknown-helpers', whitelist: ['addSomethingNonmagic']]
+    options: ['whenUsingUnknownHelpers', whitelist: ['addSomethingNonmagic']]
   ,
     # whitelist call
     code: '''
@@ -56,7 +56,7 @@ tests =
         addSomethingNonmagic
       )
     '''
-    options: ['when-using-unknown-helpers', whitelist: ['addSomethingNonmagic']]
+    options: ['whenUsingUnknownHelpers', whitelist: ['addSomethingNonmagic']]
   ]
   invalid: [
     # always
@@ -82,14 +82,14 @@ tests =
     '''
     errors: [error()]
   ,
-    # when-using-unknown-helpers
+    # whenUsingUnknownHelpers
     code: '''
       flow(
         addSomething()
       )
     '''
     errors: [error()]
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     code: '''
       flow(
@@ -97,7 +97,7 @@ tests =
       )
     '''
     errors: [error()]
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     # nested flow()
     code: '''
@@ -108,7 +108,7 @@ tests =
       )
     '''
     errors: [error(), error()]
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     # immediately-invoked functions are not ok
     code: '''
@@ -117,7 +117,7 @@ tests =
       )
     '''
     errors: [error()]
-    options: ['when-using-unknown-helpers']
+    options: ['whenUsingUnknownHelpers']
   ,
     # shouldFix
     code: '''

--- a/src/tests/prefer-flowmax.coffee
+++ b/src/tests/prefer-flowmax.coffee
@@ -41,6 +41,22 @@ tests =
       )
     '''
     options: ['when-using-unknown-helpers']
+  ,
+    # whitelist call
+    code: '''
+      flow(
+        addSomethingNonmagic()
+      )
+    '''
+    options: ['when-using-unknown-helpers', whitelist: ['addSomethingNonmagic']]
+  ,
+    # whitelist call
+    code: '''
+      flow(
+        addSomethingNonmagic
+      )
+    '''
+    options: ['when-using-unknown-helpers', whitelist: ['addSomethingNonmagic']]
   ]
   invalid: [
     # always

--- a/src/tests/prefer-flowmax.coffee
+++ b/src/tests/prefer-flowmax.coffee
@@ -1,0 +1,130 @@
+{rules: {'prefer-flowmax': rule}} = require '..'
+{RuleTester} = require 'eslint'
+
+ruleTester = new RuleTester()
+
+error = ->
+  message: "Use flowMax() instead"
+
+tests =
+  valid: [
+    code: '''
+      a = 1
+    '''
+  ,
+    code: '''
+      flow(
+        addProps({a: 1})
+      )
+    '''
+    options: ['when-using-unknown-helpers']
+  ,
+    # don't duplicate needs-flowmax
+    code: '''
+      flow(
+        addPropTypes({a: 1})
+      )
+    '''
+    options: ['when-using-unknown-helpers']
+  ,
+    code: '''
+      flow(
+        branchPure(({x}) => x, returns(() => 2))
+      )
+    '''
+    options: ['when-using-unknown-helpers']
+  ,
+    # functions are ok
+    code: '''
+      flow(
+        ({x}) => x
+      )
+    '''
+    options: ['when-using-unknown-helpers']
+  ]
+  invalid: [
+    # always
+    code: '''
+      flow(
+        addProps({a: 1})
+      )
+    '''
+    # don't fix unless shouldFix
+    output: '''
+      flow(
+        addProps({a: 1})
+      )
+    '''
+    errors: [error()]
+    options: ['always']
+  ,
+    # default is always
+    code: '''
+      flow(
+        addProps({a: 1})
+      )
+    '''
+    errors: [error()]
+  ,
+    # when-using-unknown-helpers
+    code: '''
+      flow(
+        addSomething()
+      )
+    '''
+    errors: [error()]
+    options: ['when-using-unknown-helpers']
+  ,
+    code: '''
+      flow(
+        addSomething
+      )
+    '''
+    errors: [error()]
+    options: ['when-using-unknown-helpers']
+  ,
+    # nested flow()
+    code: '''
+      flow(
+        flow(
+          addSomething
+        )()
+      )
+    '''
+    errors: [error(), error()]
+    options: ['when-using-unknown-helpers']
+  ,
+    # immediately-invoked functions are not ok
+    code: '''
+      flow(
+        (({x}) => doSomethingMagic(x))()
+      )
+    '''
+    errors: [error()]
+    options: ['when-using-unknown-helpers']
+  ,
+    # shouldFix
+    code: '''
+      flow(
+        addProps({a: 1})
+      )
+    '''
+    output: '''
+      flowMax(
+        addProps({a: 1})
+      )
+    '''
+    errors: [error()]
+    options: ['always', shouldFix: yes]
+  ]
+
+config =
+  parser: 'babel-eslint'
+  parserOptions:
+    ecmaVersion: 2018
+    ecmaFeatures:
+      jsx: yes
+
+Object.assign(test, config) for test in [...tests.valid, ...tests.invalid]
+
+ruleTester.run 'prefer-flowmax', rule, tests

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -30,6 +30,10 @@ nonmagicHelperNames = [
   'branchPure'
 ]
 
+isNonmagicHelper = (node) ->
+  return no unless node?.callee?.type is 'Identifier'
+  node.callee.name in nonmagicHelperNames
+
 isFunction = (node) ->
   node?.type in ['FunctionExpression', 'ArrowFunctionExpression']
 
@@ -41,4 +45,4 @@ getFlowToFlowMaxFixer = ({node, context}) ->
   (fixer) ->
     fixer.replaceText node.callee, 'flowMax'
 
-module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isBranchPure, getFlowToFlowMaxFixer}
+module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer}


### PR DESCRIPTION
In this PR:
- new `prefer-flowmax` rule

Compared to what I proposed in #3, I didn't include `always-component` option since I realized there's no good heuristic for knowing whether a "secondary helper" is intended for use in a component or not

Also changed casing from `when-using-unknown-helpers` to `whenUsingUnknownHelpers` to be more idiomatic/YAML-friendly (?)