### PR TITLE
Handle magic branchPure() in no-unnecessary-flowmax

### DIFF
--- a/src/rules/no-unnecessary-flowmax.coffee
+++ b/src/rules/no-unnecessary-flowmax.coffee
@@ -1,6 +1,6 @@
-{isFlowMax, nonmagicHelperNames, isFunction} = require '../util'
+{isFlowMax, nonmagicHelperNames, isFunction, isBranchPure} = require '../util'
 
-isNonMagic = (node) ->
+isNonmagic = (node) ->
   return yes unless node?
   return yes if isFunction node
   {callee} = node
@@ -19,5 +19,8 @@ module.exports =
     CallExpression: (node) ->
       return unless isFlowMax node
       for argument in node.arguments
-        return unless isNonMagic argument
+        return unless isNonmagic argument
+        if isBranchPure argument
+          for branchPureArgument in argument.arguments
+            return unless isNonmagic branchPureArgument
       context.report node, "Unnecessary use of flowMax()"

--- a/src/tests/no-unnecessary-flowmax.coffee
+++ b/src/tests/no-unnecessary-flowmax.coffee
@@ -38,7 +38,19 @@ tests =
   ,
     code: '''
       flowMax(
+        branchPure(({x}) => x > 1, renderNothing()),
+      )
+    '''
+  ,
+    code: '''
+      flowMax(
         branch(({x}) => x > 1, returns(() => 3)),
+      )
+    '''
+  ,
+    code: '''
+      flowMax(
+        branchPure(({x}) => x > 1, returns(() => 3)),
       )
     '''
   ,


### PR DESCRIPTION
In this PR:
- fix `no-unnecessary-flowmax` to correctly not flag non-nonmagic `branchPure()`