### PR TITLE
helperRegex for prefer-flowmax

### DIFF
--- a/src/tests/prefer-flowmax.coffee
+++ b/src/tests/prefer-flowmax.coffee
@@ -57,6 +57,14 @@ tests =
       )
     '''
     options: ['whenUsingUnknownHelpers', whitelist: ['addSomethingNonmagic']]
+  ,
+    # helperRegex defaults to add.*
+    code: '''
+      flow(
+        something
+      )
+    '''
+    options: ['whenUsingUnknownHelpers']
   ]
   invalid: [
     # always
@@ -98,6 +106,15 @@ tests =
     '''
     errors: [error()]
     options: ['whenUsingUnknownHelpers']
+  ,
+    # helperRegex
+    code: '''
+      flow(
+        something
+      )
+    '''
+    errors: [error()]
+    options: ['whenUsingUnknownHelpers', {helperRegex: 'add.*|some.*'}]
   ,
     # nested flow()
     code: '''


### PR DESCRIPTION
In this PR:
- added `helperRegex` option to `prefer-flowmax` defaulting to `add.*`

In trying out `prefer-flowmax` on a project, I didn't like how it was flagging "standard" (ie non-component) uses of `flow()`. I find there to be readability value in having those be `flow()`'s unless they're doing something magic

So the best thing I could think of was to impose a regex for what the name of a "helper" (that could contain magic) looks like

This is pretty similar to what the React hooks ESLint plugin does I believe (makes assumptions that custom hooks start with `use`)

If you didn't want to follow any convention, you could just use eg `helperRegex: '.*'`