### PR TITLE
require-adddisplayname rule

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
 {flow, map: fmap, fromPairs: ffromPairs} = require 'lodash/fp'
 
-ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax', 'no-flowmax-in-forwardref', 'dependencies']
+ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax', 'no-flowmax-in-forwardref', 'dependencies', 'require-adddisplayname']
 
 rules = do flow(
   -> ruleNames

--- a/src/rules/require-adddisplayname.coffee
+++ b/src/rules/require-adddisplayname.coffee
@@ -1,0 +1,36 @@
+{shouldFix, getAddDisplayNameFixer} = require '../util'
+
+module.exports =
+  meta:
+    docs:
+      description: 'Flag flowMax() components without addDisplayName()'
+      category: 'Possible Errors'
+      recommended: yes
+    schema: []
+    fixable: 'code'
+
+  create: (context) ->
+    report = (node) ->
+      context.report {
+        node,
+        message: 'Set a display name with addDisplayName()'
+        fix:
+          if shouldFix {context}
+            getAddDisplayNameFixer {node, context}
+          else
+            null
+      }
+
+    "CallExpression[callee.name='flowMax']":
+      (node) ->
+        return unless node.arguments?.length
+        return unless do ->
+          return no unless node.parent?.type is 'VariableDeclarator'
+          return no unless node.parent.id.type is 'Identifier'
+          return no unless /^[A-Z]/.test node.parent.id.name
+          yes
+        for argument in node.arguments
+          if argument?.type is 'CallExpression' and argument.callee.type is 'Identifier' and argument.callee.name is 'addDisplayName'
+            return
+
+        report node

--- a/src/tests/require-adddisplayname.coffee
+++ b/src/tests/require-adddisplayname.coffee
@@ -1,0 +1,75 @@
+{rules: {'require-adddisplayname': rule}} = require '..'
+{RuleTester} = require 'eslint'
+
+ruleTester = new RuleTester()
+
+error =
+  message: 'Set a display name with addDisplayName()'
+
+tests =
+  valid: [
+    code: '''
+      flowMax()
+    '''
+  ,
+    code: '''
+      const Component = flowMax(
+        addDisplayName('Component'),
+        ({b}) => <div>{b}</div>
+      )
+    '''
+  ,
+    code: '''
+      const Component = flowMax(
+        addDisplayName('Something'),
+        addProps({b: 2}),
+        ({b}) => <div>{b}</div>
+      )
+    '''
+  ,
+    # not definitively a "component"
+    code: '''
+      flowMax(
+        ({b}) => <div>{b}</div>
+      )
+    '''
+  ]
+  invalid: [
+    code: '''
+      const Component = flowMax(
+        ({b}) => <div>{b}</div>
+      )
+    '''
+    settings:
+      'ad-hok/should-fix-flow-flowmax': yes
+    output: '''
+      const Component = flowMax(
+        addDisplayName('Component'), ({b}) => <div>{b}</div>
+      )
+    '''
+    errors: [error]
+  ,
+    # don't fix unless requested
+    code: '''
+      const Component = flowMax(
+        ({b}) => <div>{b}</div>
+      )
+    '''
+    output: '''
+      const Component = flowMax(
+        ({b}) => <div>{b}</div>
+      )
+    '''
+    errors: [error]
+  ]
+
+config =
+  parser: 'babel-eslint'
+  parserOptions:
+    ecmaVersion: 2018
+    ecmaFeatures:
+      jsx: yes
+
+Object.assign(test, config) for test in [...tests.valid, ...tests.invalid]
+
+ruleTester.run 'require-adddisplayname', rule, tests

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -50,7 +50,12 @@ getFlowMaxToFlowFixer = ({node, context}) ->
   (fixer) ->
     fixer.replaceText node.callee, 'flow'
 
+getAddDisplayNameFixer = ({node, context}) ->
+  (fixer) ->
+    componentName = node.parent.id.name
+    fixer.insertTextBefore node.arguments[0], "addDisplayName('#{componentName}'), "
+
 shouldFix = ({context: {settings}}) ->
   !!settings['ad-hok/should-fix-flow-flowmax']
 
-module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer, getFlowMaxToFlowFixer, shouldFix}
+module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer, getFlowMaxToFlowFixer, shouldFix, getAddDisplayNameFixer}


### PR DESCRIPTION
In this PR:
- add `require-adddisplayname` rule to flag `flowMax()` components that don't have an `addDisplayName()` (and optionally autofix)

Not in this PR:
- should probably also flag `flow()` components (but not autofix?)