### PR TITLE
Annotate handler param types

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
 {flow, map: fmap, fromPairs: ffromPairs} = require 'lodash/fp'
 
-ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax', 'no-flowmax-in-forwardref', 'dependencies', 'require-adddisplayname']
+ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax', 'no-flowmax-in-forwardref', 'dependencies', 'require-adddisplayname', 'annotate-handler-param-types']
 
 rules = do flow(
   -> ruleNames

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -8,6 +8,11 @@ rules = do flow(
   ffromPairs
 )
 
+sharedRecommendRules =
+  'ad-hok/needs-flowmax': 'error'
+  'ad-hok/prefer-flowmax': ['error', 'whenUsingUnknownHelpers']
+  'ad-hok/no-flowmax-in-forwardref': 'error'
+
 module.exports = {
   rules
   configs:
@@ -16,8 +21,12 @@ module.exports = {
       parserOptions:
         ecmaFeatures:
           jsx: yes
-      rules:
-        'ad-hok/needs-flowmax': 'error'
-        'ad-hok/prefer-flowmax': ['error', 'whenUsingUnknownHelpers']
-        'ad-hok/no-flowmax-in-forwardref': 'error'
+      rules: sharedRecommendRules
+    'recommended-typescript':
+      plugins: ['ad-hok']
+      parserOptions:
+        ecmaFeatures:
+          jsx: yes
+      rules: Object.assign sharedRecommendRules,
+        'ad-hok/annotate-handler-param-types': 'error'
 }

--- a/src/rules/annotate-handler-param-types.coffee
+++ b/src/rules/annotate-handler-param-types.coffee
@@ -1,0 +1,51 @@
+{isTypescript} = require '../util'
+
+helperNames = [
+  'addHandlers'
+  'addStateHandlers'
+]
+
+getFunctionParam = (argumentNum) -> (func) ->
+  return unless func?.type is 'ArrowFunctionExpression'
+  func.params[argumentNum] ? {
+    type: 'ObjectPattern'
+    properties: []
+  }
+
+module.exports =
+  meta:
+    docs:
+      description: 'Flag handler params without explicit type annotations'
+      category: 'Possible Errors'
+      recommended: yes
+    schema: []
+
+  create: (context) ->
+    return {} unless isTypescript context
+
+    CallExpression: (node) ->
+      {callee, arguments: args} = node
+      return unless callee?.type is 'Identifier'
+      {name} = callee
+      return unless name in helperNames
+
+      switch name
+        when 'addHandlers'
+          handlers = args[0]
+        when 'addStateHandlers'
+          handlers = args[1]
+
+      return unless handlers?.type is 'ObjectExpression'
+
+      for {value: outerFunction} in handlers.properties
+        continue unless outerFunction.type is 'ArrowFunctionExpression'
+        {body: innerFunction} = outerFunction
+        continue unless innerFunction.type is 'ArrowFunctionExpression'
+        for param in innerFunction.params
+          continue if param.typeAnnotation
+          context.report {
+            node
+            message: """
+              Parameter should be annotated to avoid implicit any-typing
+            """
+          }

--- a/src/rules/annotate-handler-param-types.coffee
+++ b/src/rules/annotate-handler-param-types.coffee
@@ -5,13 +5,6 @@ helperNames = [
   'addStateHandlers'
 ]
 
-getFunctionParam = (argumentNum) -> (func) ->
-  return unless func?.type is 'ArrowFunctionExpression'
-  func.params[argumentNum] ? {
-    type: 'ObjectPattern'
-    properties: []
-  }
-
 module.exports =
   meta:
     docs:

--- a/src/tests/annotate-handler-param-types.coffee
+++ b/src/tests/annotate-handler-param-types.coffee
@@ -1,0 +1,164 @@
+{rules: {'annotate-handler-param-types': rule}} = require '..'
+{RuleTester} = require 'eslint'
+
+ruleTester = new RuleTester()
+
+errorMissingAnnotation = """
+  Parameter should be annotated to avoid implicit any-typing
+"""
+
+tests =
+  valid: [
+    # ignore .js files
+    filename: 'test.js',
+    code: '''
+      flowMax(
+        addHandlers({
+          doSomething: () => (b) => {
+            b()
+          }
+        }),
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}) => (amount) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    ''',
+  ,
+    # ignore .jsx files
+    filename: 'test.jsx',
+    code: '''
+      flowMax(
+        addHandlers({
+          doSomething: () => (b) => {
+            b()
+          }
+        }),
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}) => (amount) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    ''',
+  ,
+    filename: 'test.ts',
+    code: '''
+      flowMax(
+        addHandlers({
+          doSomething: () => (b: () => void) => {
+            b()
+          }
+        }),
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}) => (amount: number) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    ''',
+  ]
+  invalid: [
+    filename: 'test.ts',
+    code: '''
+      flowMax(
+        addHandlers({
+          doSomething: () => (b) => {
+            b()
+          }
+        }),
+      )
+    ''',
+    errors: [errorMissingAnnotation]
+  ,
+    filename: 'test.tsx',
+    code: '''
+      flowMax(
+        addHandlers({
+          doSomething: () => (b) => {
+            b()
+          }
+        }),
+      )
+    ''',
+    errors: [errorMissingAnnotation]
+  ,
+    filename: 'test.ts',
+    code: '''
+      flowMax(
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}) => (amount) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    ''',
+    errors: [errorMissingAnnotation]
+  ,
+    filename: 'test.tsx',
+    code: '''
+      flowMax(
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}) => (amount) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    ''',
+    errors: [errorMissingAnnotation]
+  ,
+    # complex param
+    filename: 'test.tsx',
+    code: '''
+      flowMax(
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}) => ({amount}) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    ''',
+    errors: [errorMissingAnnotation]
+  ]
+
+config =
+  parser: 'babel-eslint'
+  parserOptions:
+    ecmaVersion: 2018
+    ecmaFeatures:
+      jsx: yes
+
+Object.assign(test, config) for test in [...tests.valid, ...tests.invalid]
+
+ruleTester.run 'annotate-handler-param-types', rule, tests

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -1,3 +1,5 @@
+path = require 'path'
+
 isFlowMax = (node) ->
   node?.callee?.type is 'Identifier' and node.callee.name is 'flowMax'
 
@@ -58,4 +60,8 @@ getAddDisplayNameFixer = ({node, context}) ->
 shouldFix = ({context: {settings}}) ->
   !!settings['ad-hok/should-fix-flow-flowmax']
 
-module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer, getFlowMaxToFlowFixer, shouldFix, getAddDisplayNameFixer}
+isTypescript = (context) ->
+  extension = path.extname context.getFilename()
+  extension in ['.ts', '.tsx']
+
+module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer, getFlowMaxToFlowFixer, shouldFix, getAddDisplayNameFixer, isTypescript}


### PR DESCRIPTION
In this PR:
- add `annotate-handler-param-types` rule for flagging `addHandlers()`/`addStateHandlers()` params without an explicit type annotation (because they'd be implicitly `any`-typed)
- expose `recommended-typescript` config