### PR TITLE
cleanupprops-last rule

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,6 @@
 {flow, map: fmap, fromPairs: ffromPairs} = require 'lodash/fp'
 
-ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax', 'no-flowmax-in-forwardref', 'dependencies', 'require-adddisplayname', 'annotate-handler-param-types']
+ruleNames = ['no-unnecessary-flowmax', 'needs-flowmax', 'prefer-flowmax', 'no-flowmax-in-forwardref', 'dependencies', 'require-adddisplayname', 'annotate-handler-param-types', 'cleanupprops-last']
 
 rules = do flow(
   -> ruleNames
@@ -29,4 +29,5 @@ module.exports = {
           jsx: yes
       rules: Object.assign sharedRecommendRules,
         'ad-hok/annotate-handler-param-types': 'error'
+        'ad-hok/cleanupprops-last': 'error'
 }

--- a/src/rules/cleanupprops-last.coffee
+++ b/src/rules/cleanupprops-last.coffee
@@ -24,6 +24,6 @@ module.exports =
       context.report {
         node
         message: """
-          cleanupProps() is type-unsafe unless last in chain
+          cleanupProps() is type-unsafe unless last in chain, consider removeProps()
         """
       }

--- a/src/rules/cleanupprops-last.coffee
+++ b/src/rules/cleanupprops-last.coffee
@@ -1,0 +1,29 @@
+{last} = require 'lodash'
+
+{isTypescript, isFlowOrFlowMax} = require '../util'
+
+module.exports =
+  meta:
+    docs:
+      description: "Flag uses of cleanupProps() that aren't last in a chain"
+      category: 'Possible Errors'
+      recommended: yes
+    schema: []
+
+  create: (context) ->
+    return {} unless isTypescript context
+
+    CallExpression: (node) ->
+      {callee, parent} = node
+      return unless callee?.type is 'Identifier' and callee.name is 'cleanupProps'
+
+      return unless isFlowOrFlowMax parent
+      {arguments: args} = parent
+      return if node is last args
+
+      context.report {
+        node
+        message: """
+          cleanupProps() is type-unsafe unless last in chain
+        """
+      }

--- a/src/tests/cleanupprops-last.coffee
+++ b/src/tests/cleanupprops-last.coffee
@@ -4,7 +4,7 @@
 ruleTester = new RuleTester()
 
 errorNonFinal = """
-  cleanupProps() is type-unsafe unless last in chain
+  cleanupProps() is type-unsafe unless last in chain, consider removeProps()
 """
 
 tests =

--- a/src/tests/cleanupprops-last.coffee
+++ b/src/tests/cleanupprops-last.coffee
@@ -1,0 +1,174 @@
+{rules: {'cleanupprops-last': rule}} = require '..'
+{RuleTester} = require 'eslint'
+
+ruleTester = new RuleTester()
+
+errorNonFinal = """
+  cleanupProps() is type-unsafe unless last in chain
+"""
+
+tests =
+  valid: [
+    # expected usage in .ts
+    filename: 'test.ts'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+      )
+    '''
+  ,
+    # expected usage in .tsx
+    filename: 'test.tsx'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+      )
+    '''
+  ,
+    # non-final removeProps()
+    filename: 'test.ts'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        removeProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+  ,
+    # not flagged for .js
+    filename: 'test.js'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+  ,
+    # not flagged for .jsx
+    filename: 'test.jsx'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+  ,
+    # not flagged if not in flow()/flowMax(
+    filename: 'test.ts'
+    code: '''
+      const addSomething = compose(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+    errors: [errorNonFinal]
+  ]
+  invalid: [
+    # flagged for .ts
+    filename: 'test.ts'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+    errors: [errorNonFinal]
+  ,
+    # flagged for .tsx
+    filename: 'test.tsx'
+    code: '''
+      const addSomething = flowMax(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+    errors: [errorNonFinal]
+  ,
+    # flagged for flow()
+    filename: 'test.tsx'
+    code: '''
+      const addSomething = flow(
+        addProps(() => ({
+          a: 1
+        })),
+        addProps(({a}) => ({
+          b: a + 1
+        })),
+        cleanupProps(['a']),
+        addProps({
+          c: 2
+        })
+      )
+    '''
+    errors: [errorNonFinal]
+  ]
+
+config =
+  parser: 'babel-eslint'
+  parserOptions:
+    ecmaVersion: 2018
+    ecmaFeatures:
+      jsx: yes
+
+Object.assign(test, config) for test in [...tests.valid, ...tests.invalid]
+
+ruleTester.run 'cleanupprops-last', rule, tests

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -6,6 +6,9 @@ isFlowMax = (node) ->
 isFlow = (node) ->
   node?.callee?.type is 'Identifier' and node.callee.name is 'flow'
 
+isFlowOrFlowMax = (node) ->
+  isFlowMax(node) or isFlow node
+
 magicHelperNames = [
   'returns'
   'renderNothing'
@@ -64,4 +67,4 @@ isTypescript = (context) ->
   extension = path.extname context.getFilename()
   extension in ['.ts', '.tsx']
 
-module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer, getFlowMaxToFlowFixer, shouldFix, getAddDisplayNameFixer, isTypescript}
+module.exports = {isFlowMax, isFlow, magicHelperNames, nonmagicHelperNames, isFunction, isMagic, isNonmagicHelper, isBranchPure, getFlowToFlowMaxFixer, getFlowMaxToFlowFixer, shouldFix, getAddDisplayNameFixer, isTypescript, isFlowOrFlowMax}


### PR DESCRIPTION
In this PR:
- add `cleanupprops-last` rule for flagging uses of `cleanupProps()` that aren't last in the chain (in Typescript)

Fixes #31 