### PR TITLE
Rename should-fix-flow-flowmax

### DIFF
--- a/docs/rules/needs-flowmax.md
+++ b/docs/rules/needs-flowmax.md
@@ -50,6 +50,6 @@ flowMax(
 
 ### Relevant settings
 
-* Adding `"ad-hok/should-fix-flow-flowmax": true` to your `settings` enables "fixing" `flow()` -> `flowMax()` when running ESLint in `--fix` mode. This option is intended
+* Adding `"ad-hok/should-fix-importable-names": true` to your `settings` enables "fixing" `flow()` -> `flowMax()` when running ESLint in `--fix` mode. This option is intended
 for use with [`eslint-plugin-known-imports`](https://github.com/helixbass/eslint-plugin-known-imports), which will then
 generate the `import` for `flowMax` and/or remove the `import` for `flow` as necessary

--- a/docs/rules/no-unnecessary-flowmax.md
+++ b/docs/rules/no-unnecessary-flowmax.md
@@ -34,6 +34,6 @@ flowMax(
 
 ### Relevant settings
 
-* Adding `"ad-hok/should-fix-flow-flowmax": true` to your `settings` enables "fixing" `flowMax()` -> `flow()` when running ESLint in `--fix` mode. This option is intended
+* Adding `"ad-hok/should-fix-importable-names": true` to your `settings` enables "fixing" `flowMax()` -> `flow()` when running ESLint in `--fix` mode. This option is intended
 for use with [`eslint-plugin-known-imports`](https://github.com/helixbass/eslint-plugin-known-imports), which will then
 generate the `import` for `flow` and/or remove the `import` for `flowMax` as necessary

--- a/docs/rules/prefer-flowmax.md
+++ b/docs/rules/prefer-flowmax.md
@@ -19,7 +19,7 @@ This rule uses the following optional `settings`:
 use `ad-hok` "magic" helpers. The default is `"ad-hok/possibly-magic-helper-regex": "add.*"`
 * When `"whenUsingUnknownHelpers"`, the `ad-hok/nonmagic-helper-whitelist` setting accepts an array of helper names that should be treated as
 definitely non-"magic". The `ad-hok/nonmagic-helper-whitelist` setting overrides `ad-hok/possibly-magic-helper-regex`
-* Adding `"ad-hok/should-fix-flow-flowmax": true` to your `settings` enables "fixing" `flow()` -> `flowMax()` when running ESLint in `--fix` mode. This option is intended
+* Adding `"ad-hok/should-fix-importable-names": true` to your `settings` enables "fixing" `flow()` -> `flowMax()` when running ESLint in `--fix` mode. This option is intended
 for use with [`eslint-plugin-known-imports`](https://github.com/helixbass/eslint-plugin-known-imports), which will then
 generate the `import` for `flowMax` and/or remove the `import` for `flow` as necessary
 

--- a/src/tests/needs-flowmax.coffee
+++ b/src/tests/needs-flowmax.coffee
@@ -77,7 +77,7 @@ tests =
         returns(() => 1)
       )
     '''
-    # don't fix unless should-fix-flow-flowmax is set
+    # don't fix unless should-fix-importable-names is set
     output: '''
       flow(
         returns(() => 1)
@@ -176,7 +176,7 @@ tests =
     '''
     errors: [error 'returns']
     settings:
-      'ad-hok/should-fix-flow-flowmax': yes
+      'ad-hok/should-fix-importable-names': yes
   ]
 
 config =

--- a/src/tests/no-unnecessary-flowmax.coffee
+++ b/src/tests/no-unnecessary-flowmax.coffee
@@ -129,7 +129,7 @@ tests =
     '''
     errors: [error()]
     settings:
-      'ad-hok/should-fix-flow-flowmax': yes
+      'ad-hok/should-fix-importable-names': yes
   ]
 
 config =

--- a/src/tests/prefer-flowmax.coffee
+++ b/src/tests/prefer-flowmax.coffee
@@ -109,7 +109,7 @@ tests =
         addProps({a: 1})
       )
     '''
-    # don't fix unless should-fix-flow-flowmax
+    # don't fix unless should-fix-importable-names
     output: '''
       flow(
         addProps({a: 1})
@@ -165,7 +165,7 @@ tests =
     errors: [error()]
     options: ['whenUsingUnknownHelpers']
   ,
-    # should-fix-flow-flowmax
+    # should-fix-importable-names
     code: '''
       flow(
         addProps({a: 1})
@@ -179,7 +179,7 @@ tests =
     errors: [error()]
     options: ['always']
     settings:
-      'ad-hok/should-fix-flow-flowmax': yes
+      'ad-hok/should-fix-importable-names': yes
   ,
     # ternary isn't ok if one of its branches is a helper
     code: '''

--- a/src/tests/require-adddisplayname.coffee
+++ b/src/tests/require-adddisplayname.coffee
@@ -40,7 +40,7 @@ tests =
       )
     '''
     settings:
-      'ad-hok/should-fix-flow-flowmax': yes
+      'ad-hok/should-fix-importable-names': yes
     output: '''
       const Component = flowMax(
         addDisplayName('Component'), ({b}) => <div>{b}</div>

--- a/src/util.coffee
+++ b/src/util.coffee
@@ -64,7 +64,7 @@ getAddDisplayNameFixer = ({node}) ->
     )
 
 shouldFix = ({context: {settings}}) ->
-  !!settings['ad-hok/should-fix-flow-flowmax']
+  !!settings['ad-hok/should-fix-importable-names']
 
 isTypescript = (context) ->
   extension = path.extname context.getFilename()


### PR DESCRIPTION
In this PR:
- rename `should-fix-flow-flowmax` setting to the more generic `should-fix-importable-names`

Fixes #30 