### PR TITLE
Add effects option to dependencies rule

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -18,9 +18,8 @@ rules = do flow(
 )
 
 sharedRecommendRules =
-  'ad-hok/needs-flowmax': 'error'
-  'ad-hok/prefer-flowmax': ['error', 'whenUsingUnknownHelpers']
   'ad-hok/no-flowmax-in-forwardref': 'error'
+  'ad-hok/dependencies': ['error', {effects: no}]
 
 module.exports = {
   rules

--- a/src/rules/dependencies.coffee
+++ b/src/rules/dependencies.coffee
@@ -1,13 +1,5 @@
 {startsWith} = require 'lodash'
 
-helperNames = [
-  'addProps'
-  'addEffect'
-  'addLayoutEffect'
-  'addHandlers'
-  'addStateHandlers'
-]
-
 getFunctionParam = (argumentNum) -> (func) ->
   return unless func?.type is 'ArrowFunctionExpression'
   func.params[argumentNum] ?
@@ -20,9 +12,20 @@ module.exports =
       description: 'Flag missing/unnecessary dependencies'
       category: 'Possible Errors'
       recommended: yes
-    schema: []
+    schema: [
+      type: 'object'
+      properties:
+        effects:
+          type: 'boolean'
+      additionalProperties: no
+    ]
 
   create: (context) ->
+    {effects = yes} = context.options[0] ? {}
+
+    helperNames = ['addProps', 'addHandlers', 'addStateHandlers']
+    helperNames = [...helperNames, 'addEffect', 'addLayoutEffect'] if effects
+
     reportUnused = (node) ->
       context.report {
         node

--- a/src/tests/dependencies.coffee
+++ b/src/tests/dependencies.coffee
@@ -174,6 +174,14 @@ tests =
         }), ['a.b']),
       )
     '''
+  ,
+    # effects option
+    code: '''
+      addEffect(({a}) => () => {
+        a()
+      }, [])
+    '''
+    options: [effects: no]
   ]
   invalid: [
     # missing dependencies
@@ -340,6 +348,20 @@ tests =
       }, ['a.c'])
     '''
     errors: [errorMissing('a.b'), errorUnnecessary 'a.c']
+  ,
+    # effects options doesn't affect other chcking
+    code: '''
+      addStateHandlers(
+        {a: 1},
+        {
+          b: (_, {c, d}) => () => ({a: 2}),
+          e: (_, {f}) => () => ({a: 3}),
+        },
+        ['d']
+      )
+    '''
+    errors: [errorMissing('c'), errorMissing 'f']
+    options: [effects: no]
   ]
 
 config =

--- a/src/tests/dependencies.coffee
+++ b/src/tests/dependencies.coffee
@@ -349,7 +349,7 @@ tests =
     '''
     errors: [errorMissing('a.b'), errorUnnecessary 'a.c']
   ,
-    # effects options doesn't affect other chcking
+    # effects options doesn't affect other checking
     code: '''
       addStateHandlers(
         {a: 1},


### PR DESCRIPTION
In this PR:
- add `effects` option to `dependencies` rule to enable not running it for effects
- add `dependencies` rule with `effects: false` to the `recommended` config