### PR TITLE
Check addExtendedHandlers() in annotate-handler-param-types

### DIFF
--- a/src/rules/annotate-handler-param-types.coffee
+++ b/src/rules/annotate-handler-param-types.coffee
@@ -1,6 +1,6 @@
 {isTypescript} = require '../util'
 
-helperNames = ['addHandlers', 'addStateHandlers']
+helperNames = ['addHandlers', 'addStateHandlers', 'addExtendedHandlers']
 
 module.exports =
   meta:
@@ -20,7 +20,7 @@ module.exports =
       return unless name in helperNames
 
       switch name
-        when 'addHandlers'
+        when 'addHandlers', 'addExtendedHandlers'
           handlers = args[0]
         when 'addStateHandlers'
           handlers = args[1]

--- a/src/tests/annotate-handler-param-types.coffee
+++ b/src/tests/annotate-handler-param-types.coffee
@@ -150,6 +150,18 @@ tests =
       )
     '''
     errors: [errorMissingAnnotation]
+  ,
+    filename: 'test.ts'
+    code: '''
+      flowMax(
+        addExtendedHandlers({
+          doSomething: () => (b) => {
+            b()
+          }
+        }),
+      )
+    '''
+    errors: [errorMissingAnnotation]
   ]
 
 config =


### PR DESCRIPTION
In this PR:
- also check `ad-hok-utils`'s `addExtendedHandlers()` in `annotate-handler-param-types`

Fixes #44 