### PR TITLE
getcontexthelpers-argument rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -41,6 +41,7 @@ rules:
   coffee/id-length: off
   coffee/complexity: off
   coffee/prefer-object-spread: off
+  coffee/no-loop-func: off
 env:
   node: true
   es6: true

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If you don't use the preset, include the rules that you wish to use:
 Typescript-specific rules:
 * [`ad-hok/cleanupprops-last`](./docs/rules/cleanupprops-last.md) - check that `cleanupProps()` is only used at the end of ad-hok helper chains
 * [`ad-hok/annotate-handler-param-types`](./docs/rules/annotate-handler-param-types.md) - check that handler params have explicit type annotations
+* [`ad-hok/getcontexthelpers-argument`](./docs/rules/getcontexthelpers-argument.md) - autofix [`getContextHelpers()`](https://github.com/helixbass/ad-hok-utils#getcontexthelpers)'s argument
 
 
 ## Configuration presets
@@ -123,6 +124,7 @@ The rules enabled in this configuration (in addition to the rules listed for the
 
 * [`ad-hok/annotate-handler-param-types`](./docs/rules/annotate-handler-param-types.md)
 * [`ad-hok/cleanupprops-last`](./docs/rules/cleanupprops-last.md)
+* [`ad-hok/getcontexthelpers-argument`](./docs/rules/getcontexthelpers-argument.md)
 
 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you don't use the preset, include the rules that you wish to use:
 Typescript-specific rules:
 * [`ad-hok/cleanupprops-last`](./docs/rules/cleanupprops-last.md) - check that `cleanupProps()` is only used at the end of ad-hok helper chains
 * [`ad-hok/annotate-handler-param-types`](./docs/rules/annotate-handler-param-types.md) - check that handler params have explicit type annotations
-* [`ad-hok/getcontexthelpers-argument`](./docs/rules/getcontexthelpers-argument.md) - autofix [`getContextHelpers()`](https://github.com/helixbass/ad-hok-utils#getcontexthelpers)'s argument
+* [`ad-hok/getcontexthelpers-argument`](./docs/rules/getcontexthelpers-argument.md) - autofix [`getContextHelpers()`](https://github.com/helixbass/ad-hok-utils#getcontexthelpersgetcontexthelpersfrominitialvalues)'s argument
 
 
 ## Configuration presets

--- a/docs/rules/getcontexthelpers-argument.md
+++ b/docs/rules/getcontexthelpers-argument.md
@@ -1,0 +1,53 @@
+# ad-hok/getcontexthelpers-argument
+
+This rule flags when
+[`getContextHelpers()`](https://github.com/helixbass/ad-hok-utils#getcontexthelpersgetcontexthelpersfrominitialvalues)'s
+`toObjectKeys()`argument is out-of-sync with the declared context type
+
+It is primarily intended for autofixing since Typescript will also flag mismatches between the context type vs argument
+
+### Relevant settings
+
+* Adding `"ad-hok/should-fix-importable-names": true` to your `settings` enables "fixing" a completely missing `getContextHelpers()`
+argument (`toObjectKeys()`) when running ESLint in `--fix` mode. This option is intended
+for use with [`eslint-plugin-known-imports`](https://github.com/helixbass/eslint-plugin-known-imports), which will then
+generate the `import` for `toObjectKeys` as necessary
+
+
+#### :-1: Examples of **incorrect** code for this rule:
+```js
+/*eslint ad-hok/getcontexthelpers-argument: "error"*/
+
+const [addMyContextProvider, addMyContext] = getContextHelpers<{
+  a: string
+  b: number
+}>(toObjectKeys(['a']))
+
+
+
+const [addMyContextProvider, addMyContext] = getContextHelpers<{
+  a: string
+  b: number
+}>(toObjectKeys(['a', 'b', 'c']))
+```
+
+
+#### :-1: Examples of **incorrect** code for this rule with the `"ad-hok/should-fix-importable-names": true` setting:
+```js
+/*eslint ad-hok/getcontexthelpers-argument: "error"*/
+
+const [addMyContextProvider, addMyContext] = getContextHelpers<{
+  a: string
+  b: number
+}>()
+```
+
+#### :+1: Examples of **correct** code for this rule:
+```js
+/*eslint ad-hok/needs-flowmax: "error"*/
+
+const [addMyContextProvider, addMyContext] = getContextHelpers<{
+  a: string
+  b: number
+}>(toObjectKeys(['a', 'b']))
+```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": ">=4.14.0"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^3.9.1",
     "babel-eslint": "^10.0.1",
     "coffeescript": "^2.5.0",
     "eslint": "^7",
@@ -40,7 +41,8 @@
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^5.2.0",
     "prettier": "github:helixbass/prettier#prettier-v2.1.0-dev.100-gitpkg",
-    "prettier-plugin-coffeescript": "^0.1.5-beta.1"
+    "prettier-plugin-coffeescript": "^0.1.5-beta.1",
+    "typescript": "^4.0.2"
   },
   "dependencies": {
     "lodash": "^4.17.15"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -9,6 +9,7 @@ ruleNames = [
   'require-adddisplayname'
   'annotate-handler-param-types'
   'cleanupprops-last'
+  'getcontexthelpers-argument'
 ]
 
 rules = do flow(
@@ -38,4 +39,5 @@ module.exports = {
       rules: Object.assign {}, sharedRecommendRules,
         'ad-hok/annotate-handler-param-types': 'error'
         'ad-hok/cleanupprops-last': 'error'
+        'ad-hok/getcontexthelpers-argument': 'error'
 }

--- a/src/rules/getcontexthelpers-argument.coffee
+++ b/src/rules/getcontexthelpers-argument.coffee
@@ -1,0 +1,105 @@
+{isString} = require 'lodash'
+
+{isTypescript, shouldFix} = require '../util'
+
+module.exports =
+  meta:
+    docs:
+      description: 'Flag invalid calls to getContextHelpers()'
+      category: 'Possible Errors'
+      recommended: yes
+    schema: []
+    fixable: 'code'
+
+  create: (context) ->
+    return {} unless isTypescript context
+
+    CallExpression: (node) ->
+      {callee, typeParameters, arguments: args} = node
+      return unless (
+        callee?.type is 'Identifier' and callee.name is 'getContextHelpers'
+      )
+
+      return unless typeParameters
+      {params} = typeParameters
+      return unless params?.length
+      [param] = params
+      return unless param.type is 'TSTypeLiteral'
+      typeKeys = []
+      for property in param.members
+        return unless property.type is 'TSPropertySignature'
+        return unless property.key?.type is 'Identifier'
+        typeKeys.push property.key.name
+
+      if args.length is 0
+        return unless shouldFix {context}
+        context.report {
+          node
+          message: '''
+            getContextHelpers() expects a single argument
+          '''
+          fix: (fixer) ->
+            sourceCode = context.getSourceCode()
+            lastToken = sourceCode.getLastToken node
+            return unless lastToken.value is ')'
+            fixer.insertTextBefore(
+              lastToken
+              "toObjectKeys([#{("'#{key}'" for key in typeKeys).join ', '}])"
+            )
+        }
+        return
+
+      [arg] = args
+      return unless arg.type is 'CallExpression'
+      {callee: toObjectKeysCallee, arguments: toObjectKeysArgs} = arg
+      return unless (
+        toObjectKeysCallee.type is 'Identifier' and
+        toObjectKeysCallee.name is 'toObjectKeys'
+      )
+      return unless toObjectKeysArgs.length
+      [toObjectKeysArg] = toObjectKeysArgs
+      return unless toObjectKeysArg.type is 'ArrayExpression'
+      arrayKeys = []
+      for arrayElement, index in toObjectKeysArg.elements
+        return unless (
+          arrayElement?.type is 'Literal' and isString arrayElement.value
+        )
+        arrayKeys.push {
+          node: arrayElement
+          index
+        }
+
+      for typeKey in typeKeys
+        continue if arrayKeys.find ({node: {value}}) -> value is typeKey
+        context.report {
+          node
+          message: """
+            Key "#{typeKey}" is present in the context type but not the toObjectKeys() argument
+          """
+          fix: (fixer) ->
+            sourceCode = context.getSourceCode()
+            lastToken = sourceCode.getLastToken toObjectKeysArg
+            return unless lastToken.value is ']'
+            fixer.insertTextBefore(
+              lastToken
+              "#{if arrayKeys.length then ', ' else ''}'#{typeKey}'"
+            )
+        }
+
+      numArrayKeys = toObjectKeysArg.elements.length
+      for arrayKey in arrayKeys
+        # eslint-disable-next-line coffee/no-shadow
+        continue if typeKeys.find (typeKey) -> typeKey is arrayKey.node.value
+        context.report
+          node: arrayKey.node
+          message: """
+            Key "#{arrayKey.node.value}" is not present in the context type
+          """
+          fix: (fixer) ->
+            if arrayKey.index is numArrayKeys - 1
+              fixer.remove arrayKey.node
+            else
+              fixer.removeRange [
+                arrayKey.node.range[0]
+                toObjectKeysArg.elements[arrayKey.index + 1].range[0]
+              ]

--- a/src/tests/getcontexthelpers-argument.coffee
+++ b/src/tests/getcontexthelpers-argument.coffee
@@ -1,0 +1,192 @@
+{rules: {'getcontexthelpers-argument': rule}} = require '..'
+{RuleTester} = require 'eslint'
+
+ruleTester = new RuleTester()
+
+errorMissingArgument = '''
+  getContextHelpers() expects a single argument
+'''
+errorMissingKey = (key) -> """
+  Key "#{key}" is present in the context type but not the toObjectKeys() argument
+"""
+errorUnknownKey = (key) -> """
+  Key "#{key}" is not present in the context type
+"""
+
+tests =
+  valid: [
+    # expected usage in .ts
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b']))
+    '''
+  ,
+    # expected usage in .tsx
+    filename: 'test.tsx'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b']))
+    '''
+  ,
+    # not using toObjectKeys()
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(foo(['a']))
+    '''
+  ,
+    # passing toObjectKeys() a non-array
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(someKeys))
+    '''
+  ,
+    # ordered differently
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['b', 'a']))
+    '''
+  ,
+    # not flagged for .js
+    filename: 'test.js'
+    code: '''
+      getContextHelpers(toObjectKeys(['a', 'b']))
+    '''
+  ,
+    # not flagged for .jsx
+    filename: 'test.jsx'
+    code: '''
+      getContextHelpers(toObjectKeys(['a', 'b']))
+    '''
+  ,
+    # doesn't flag missing argument without should-fix-importable-names setting
+    # (because Typescript will flag it)
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>()
+    '''
+  ]
+  invalid: [
+    # flagged for .ts
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a']))
+    '''
+    output: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b']))
+    '''
+    errors: [errorMissingKey 'b']
+  ,
+    # flagged for .tsx
+    filename: 'test.tsx'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a']))
+    '''
+    output: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b']))
+    '''
+    errors: [errorMissingKey 'b']
+  ,
+    # flag + autofix missing argument with should-fix-importable-names setting
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>()
+    '''
+    output: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b']))
+    '''
+    errors: [errorMissingArgument]
+    settings:
+      'ad-hok/should-fix-importable-names': yes
+  ,
+    # extra keys
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'c', 'b']))
+    '''
+    output: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b']))
+    '''
+    errors: [errorUnknownKey 'c']
+  ,
+    # extra key last
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b', 'c']))
+    '''
+    output: '''
+      getContextHelpers<{
+        a: string
+        b: number
+      }>(toObjectKeys(['a', 'b', ]))
+    '''
+    errors: [errorUnknownKey 'c']
+  ,
+    # empty array
+    filename: 'test.ts'
+    code: '''
+      getContextHelpers<{
+        a: string
+      }>(toObjectKeys([]))
+    '''
+    output: '''
+      getContextHelpers<{
+        a: string
+      }>(toObjectKeys(['a']))
+    '''
+    errors: [errorMissingKey 'a']
+  ]
+
+config =
+  parser: require.resolve '@typescript-eslint/parser'
+  parserOptions:
+    ecmaVersion: 2018
+    ecmaFeatures:
+      jsx: yes
+
+Object.assign test, config for test in [...tests.valid, ...tests.invalid]
+
+ruleTester.run 'getcontexthelpers-argument', rule, tests

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,10 +110,68 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/eslint-visitor-keys@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
+  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/json-schema@^7.0.3":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
+  integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@typescript-eslint/experimental-utils@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.9.1.tgz#b140b2dc7a7554a44f8a86fb6fe7cbfe57ca059e"
+  integrity sha512-lkiZ8iBBaYoyEKhCkkw4SAeatXyBq9Ece5bZXdLe1LWBUwTszGbmbiqmQbwWA8cSYDnjWXp9eDbXpf9Sn0hLAg==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/types" "3.9.1"
+    "@typescript-eslint/typescript-estree" "3.9.1"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-3.9.1.tgz#ab7983abaea0ae138ff5671c7c7739d8a191b181"
+  integrity sha512-y5QvPFUn4Vl4qM40lI+pNWhTcOWtpZAJ8pOEQ21fTTW4xTJkRplMjMRje7LYTXqVKKX9GJhcyweMz2+W1J5bMg==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "3.9.1"
+    "@typescript-eslint/types" "3.9.1"
+    "@typescript-eslint/typescript-estree" "3.9.1"
+    eslint-visitor-keys "^1.1.0"
+
+"@typescript-eslint/types@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.9.1.tgz#b2a6eaac843cf2f2777b3f2464fb1fbce5111416"
+  integrity sha512-15JcTlNQE1BsYy5NBhctnEhEoctjXOjOK+Q+rk8ugC+WXU9rAcS2BYhoh6X4rOaXJEpIYDl+p7ix+A5U0BqPTw==
+
+"@typescript-eslint/typescript-estree@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-3.9.1.tgz#fd81cada74bc8a7f3a2345b00897acb087935779"
+  integrity sha512-IqM0gfGxOmIKPhiHW/iyAEXwSVqMmR2wJ9uXHNdFpqVvPaQ3dWg302vW127sBpAiqM9SfHhyS40NKLsoMpN2KA==
+  dependencies:
+    "@typescript-eslint/types" "3.9.1"
+    "@typescript-eslint/visitor-keys" "3.9.1"
+    debug "^4.1.1"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.9.1.tgz#92af3747cdb71509199a8f7a4f00b41d636551d1"
+  integrity sha512-zxdtUjeoSh+prCpogswMwVUJfEFmCOjdzK9rpNjNBfm6EyPt99x3RrJoBOGZO23FCt0WPKUCOL5mb/9D5LjdwQ==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
 
 acorn-jsx@^5.2.0:
   version "5.2.0"
@@ -465,7 +523,7 @@ debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1, debug@^4.1.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -709,7 +767,7 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^5.1.0:
+eslint-scope@^5.0.0, eslint-scope@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
   integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
@@ -732,7 +790,7 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^2.1.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
@@ -930,6 +988,18 @@ glob@^7.1.3:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1534,7 +1604,7 @@ rimraf@2.6.3:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.2.1:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -1738,6 +1808,18 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@^1.8.1:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tsutils@^3.17.1:
+  version "3.17.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
+  integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -1749,6 +1831,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
In this PR:
- add `getcontexthelpers-argument` rule for autofixing `getContextHelpers()`'s `toObjectKeys()` argument, and turn on by default in `recommended-typescript` config

Fixes #50 