### PR TITLE
annotate-handler-param-types: don't flag if outer handler has explicit return type

### DIFF
--- a/src/rules/annotate-handler-param-types.coffee
+++ b/src/rules/annotate-handler-param-types.coffee
@@ -29,7 +29,8 @@ module.exports =
 
       for {value: outerFunction} in handlers.properties
         continue unless outerFunction.type is 'ArrowFunctionExpression'
-        {body: innerFunction} = outerFunction
+        {body: innerFunction, returnType} = outerFunction
+        continue if returnType
         continue unless innerFunction.type is 'ArrowFunctionExpression'
         for param in innerFunction.params
           continue if param.typeAnnotation

--- a/src/tests/annotate-handler-param-types.coffee
+++ b/src/tests/annotate-handler-param-types.coffee
@@ -79,9 +79,9 @@ tests =
     code: '''
       flowMax(
         addHandlers({
-		  onChange: ({onChange}): React.ChangeEventHandler<HTMLInputElement> => (event) => {
-			onChange(event.target.value);
-		  },
+          onChange: ({onChange}): React.ChangeEventHandler<HTMLInputElement> => (event) => {
+            onChange(event.target.value);
+          },
         }),
         addStateHandlers(
           {

--- a/src/tests/annotate-handler-param-types.coffee
+++ b/src/tests/annotate-handler-param-types.coffee
@@ -73,6 +73,28 @@ tests =
         ),
       )
     '''
+  ,
+    # don't flag explicit return type on outer handler
+    filename: 'test.ts'
+    code: '''
+      flowMax(
+        addHandlers({
+		  onChange: ({onChange}): React.ChangeEventHandler<HTMLInputElement> => (event) => {
+			onChange(event.target.value);
+		  },
+        }),
+        addStateHandlers(
+          {
+            count: 0,
+          },
+          {
+            add: ({count}): ((amount: number) => void) => (amount) => ({
+              count: count + amount
+            })
+          }
+        ),
+      )
+    '''
   ]
   invalid: [
     filename: 'test.ts'

--- a/src/tests/annotate-handler-param-types.coffee
+++ b/src/tests/annotate-handler-param-types.coffee
@@ -88,7 +88,7 @@ tests =
             count: 0,
           },
           {
-            add: ({count}): ((amount: number) => void) => (amount) => ({
+            add: ({count}): ((amount: number) => {count: number}) => (amount) => ({
               count: count + amount
             })
           }


### PR DESCRIPTION
In this PR:
- per #52, `annotate-handler-param-types` shouldn't flag a handler if the "outer handler" has an explicit type annotation (since that types the inner handler's params)